### PR TITLE
[DECO-1626] Adds secrets usage

### DIFF
--- a/.github/workflows/flink-ci-template.yml
+++ b/.github/workflows/flink-ci-template.yml
@@ -28,15 +28,15 @@ on:
         type: number
     secrets:
       s3_bucket:
-        required: true
+        required: false
       s3_access_key:
-        required: true
+        required: false
       s3_secret_key:
-        required: true
+        required: false
       glue_schema_access_key:
-        required: true
+        required: false
       glue_schema_secret_key:
-        required: true
+        required: false
 
 env:
   FLINK_ARTIFACT_DIR: ${{ github.workspace }}/

--- a/.github/workflows/hadoop-2.8.3-scala-2.12-workflow.yml
+++ b/.github/workflows/hadoop-2.8.3-scala-2.12-workflow.yml
@@ -13,14 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-#
-# This file defines the Flink build for the "apache/flink" repository, including
-# the following:
-#  - PR builds (triggered through ci-bot)
-#  - custom triggered e2e tests
-#  - nightly builds
-
 name: "Hadoop 2.8.3/Java 8/Scala 2.12 (Matthias)"
 
 on: push

--- a/.github/workflows/hadoop-2.8.3-scala-2.12-workflow.yml
+++ b/.github/workflows/hadoop-2.8.3-scala-2.12-workflow.yml
@@ -24,11 +24,11 @@ jobs:
       environment: 'PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.12"'
       jdk-version: 8
     secrets:
-      s3_bucket: ""
-      s3_access_key: ""
-      s3_secret_key: ""
-      glue_schema_access_key: ""
-      glue_schema_secret_key: ""
+      s3_bucket: ${{ secrets.IT_CASE_S3_BUCKET }}
+      s3_access_key: ${{ secrets.IT_CASE_S3_ACCESS_KEY }}
+      s3_secret_key: ${{ secrets.IT_CASE_S3_SECRET_KEY }}
+      glue_schema_access_key: ${{ secrets.IT_CASE_GLUE_SCHEMA_ACCESS_KEY }}
+      glue_schema_secret_key: ${{ secrets.IT_CASE_GLUE_SCHEMA_SECRET_KEY }}
   docs-404-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/hadoop-2.8.3-scala-2.12-workflow.yml
+++ b/.github/workflows/hadoop-2.8.3-scala-2.12-workflow.yml
@@ -19,7 +19,7 @@ on: [push, workflow_dispatch]
 
 jobs:
   ci:
-    uses: ververica/flink/.github/workflows/flink-ci-template.yml@hackathon2021b-matthias
+    uses: ververica/flink/.github/workflows/flink-ci-template.yml@master
     with:
       environment: 'PROFILE="-Dhadoop.version=2.8.3 -Dinclude_hadoop_aws -Dscala-2.12"'
       jdk-version: 8

--- a/.github/workflows/hadoop-2.8.3-scala-2.12-workflow.yml
+++ b/.github/workflows/hadoop-2.8.3-scala-2.12-workflow.yml
@@ -23,11 +23,7 @@
 
 name: "Hadoop 2.8.3/Java 8/Scala 2.12 (Matthias)"
 
-on:
-  push:
-    branches:
-      - hackathon2021b-matthias
-  workflow_dispatch:
+on: push
 
 jobs:
   ci:

--- a/.github/workflows/hadoop-2.8.3-scala-2.12-workflow.yml
+++ b/.github/workflows/hadoop-2.8.3-scala-2.12-workflow.yml
@@ -15,7 +15,7 @@
 
 name: "Hadoop 2.8.3/Java 8/Scala 2.12 (Matthias)"
 
-on: push
+on: [push, workflow_dispatch]
 
 jobs:
   ci:

--- a/flink-end-to-end-tests/flink-glue-schema-registry-avro-test/src/test/java/org/apache/flink/glue/schema/registry/test/GlueSchemaRegistryAvroKinesisITCase.java
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-avro-test/src/test/java/org/apache/flink/glue/schema/registry/test/GlueSchemaRegistryAvroKinesisITCase.java
@@ -39,6 +39,7 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
@@ -59,6 +60,7 @@ import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfi
 
 /** End-to-end test for Glue Schema Registry AVRO format using Kinesalite. */
 @Category(value = {TravisGroup1.class})
+@Ignore("see discussion on https://issues.apache.org/jira/browse/FLINK-23389")
 public class GlueSchemaRegistryAvroKinesisITCase extends TestLogger {
     private static final String INPUT_STREAM = "gsr_avro_input_stream";
     private static final String OUTPUT_STREAM = "gsr_avro_output_stream";

--- a/flink-end-to-end-tests/flink-glue-schema-registry-json-test/src/test/java/org/apache/flink/glue/schema/registry/test/json/GlueSchemaRegistryJsonKinesisITCase.java
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-json-test/src/test/java/org/apache/flink/glue/schema/registry/test/json/GlueSchemaRegistryJsonKinesisITCase.java
@@ -36,6 +36,7 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.Timeout;
@@ -55,6 +56,7 @@ import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfi
 
 /** End-to-end test for Glue Schema Registry Json format using Kinesalite. */
 @Category(value = {TravisGroup1.class})
+@Ignore("see discussion on https://issues.apache.org/jira/browse/FLINK-23389")
 public class GlueSchemaRegistryJsonKinesisITCase extends TestLogger {
     private static final String INPUT_STREAM = "gsr_json_input_stream";
     private static final String OUTPUT_STREAM = "gsr_json_output_stream";

--- a/tools/azure-pipelines/debug_files_utils.sh
+++ b/tools/azure-pipelines/debug_files_utils.sh
@@ -21,6 +21,10 @@ function prepare_debug_files {
 	MODULE=$@
 	export DEBUG_FILES_OUTPUT_DIR="$AGENT_TEMPDIRECTORY/debug_files"
 	export DEBUG_FILES_NAME="$(echo $MODULE | tr -c '[:alnum:]\n\r' '_')-$(date +%s)"
+	# make environment variables available in AzureCI workflow configurations
+	echo "##vso[task.setvariable variable=DEBUG_FILES_OUTPUT_DIR]$DEBUG_FILES_OUTPUT_DIR"
+	echo "##vso[task.setvariable variable=DEBUG_FILES_NAME]$DEBUG_FILES_NAME"
+	# make environment variables available in Github Actions workflow configuration
   echo "::set-output name=debug-files-output-dir::${DEBUG_FILES_OUTPUT_DIR}"
   echo "::set-output name=debug-files-name::${DEBUG_FILES_NAME}"
 	mkdir -p $DEBUG_FILES_OUTPUT_DIR || { echo "FAILURE: cannot create debug files directory '${DEBUG_FILES_OUTPUT_DIR}'." ; exit 1; }


### PR DESCRIPTION
## What is the purpose of the change

We want to enable secret usage after they were added to the `ververica/flink` repository.

## Brief change log

* Adds secrets
* Adds secrets
* Makes secrets optional
* hotfix: Change trigger for workflow

## Verifying this change

Manually verified

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
